### PR TITLE
Implement parsing of YAML streams

### DIFF
--- a/backend/cmd/kubeyaml/kubeyaml_test.go
+++ b/backend/cmd/kubeyaml/kubeyaml_test.go
@@ -10,6 +10,7 @@ import (
 func TestIntegrations(t *testing.T) {
 	testcases := []struct {
 		filename       string
+		extraArgs      string
 		shouldValidate bool
 	}{
 		// missing a selector.
@@ -18,6 +19,12 @@ func TestIntegrations(t *testing.T) {
 		{filename: "issue-8.yaml", shouldValidate: false},
 		// type Airflow is invalid. But we don't validate data
 		{filename: "issue-9.yaml", shouldValidate: true},
+		// first document is valid, second is not
+		{filename: "issue-7.yaml", shouldValidate: false},
+		// first two documents are valid, but there is an empty one (which fails)
+		{filename: "issue-7_2.yaml", shouldValidate: false},
+		// unless -ignore-empty is set
+		{filename: "issue-7_2.yaml", extraArgs: "-ignore-empty", shouldValidate: true},
 	}
 
 	for _, tc := range testcases {
@@ -27,7 +34,7 @@ func TestIntegrations(t *testing.T) {
 				t.Fatal(err)
 			}
 			var b bytes.Buffer
-			err = run(f, &b, "-silent")
+			err = run(f, &b, "-silent", tc.extraArgs)
 			if tc.shouldValidate && err != nil {
 				t.Fatal(err)
 			}

--- a/backend/cmd/kubeyaml/testdata/issue-7.yaml
+++ b/backend/cmd/kubeyaml/testdata/issue-7.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: test
+  namespace: tester
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: tes
+  sessionAffinity: None
+  type: Airflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: test
+  namespace: tester
+INVALIDspec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: tes
+  sessionAffinity: None
+  type: Airflow

--- a/backend/cmd/kubeyaml/testdata/issue-7_2.yaml
+++ b/backend/cmd/kubeyaml/testdata/issue-7_2.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: test
+  namespace: tester
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: tes
+  sessionAffinity: None
+  type: Airflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: test
+  namespace: tester
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: tes
+  sessionAffinity: None
+  type: Airflow
+---
+

--- a/backend/internal/kubernetes/errors.go
+++ b/backend/internal/kubernetes/errors.go
@@ -156,3 +156,12 @@ func NewUnknownFormatError(format string) error {
 		Format: format,
 	}
 }
+
+type EmptyDocument struct{}
+
+func (e *EmptyDocument) Error() string {
+	return fmt.Sprintf("empty document")
+}
+func NewEmptyDocument() error {
+	return &EmptyDocument{}
+}

--- a/backend/internal/kubernetes/loader.go
+++ b/backend/internal/kubernetes/loader.go
@@ -23,17 +23,11 @@ func NewLoader() *Loader {
 	return &Loader{}
 }
 
-// Load reads the input and returns the internal type representing the top level document
+// LoadManifest returns the internal type representing the top level document
 // that is properly cleaned.
-func (l *Loader) Load(reader io.Reader) (*Input, error) {
-	b, err := ioutil.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read incoming reader: %v", err)
-	}
-
-	incoming := map[interface{}]interface{}{}
-	if err := yaml.Unmarshal(b, incoming); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal yaml with error %v", err)
+func (l *Loader) LoadManifest(incoming map[interface{}]interface{}) (*Input, error) {
+	if incoming == nil {
+		return nil, NewEmptyDocument()
 	}
 
 	val, ok := incoming["apiVersion"]
@@ -63,4 +57,19 @@ func (l *Loader) Load(reader io.Reader) (*Input, error) {
 		Kind:       kind,
 		Data:       incoming,
 	}, nil
+}
+
+// Load reads the input and returns the internal type representing the top level document
+// that is properly cleaned (via LoadManifest)
+func (l *Loader) Load(reader io.Reader) (*Input, error) {
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read incoming reader: %v", err)
+	}
+
+	incoming := map[interface{}]interface{}{}
+	if err := yaml.Unmarshal(b, incoming); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal yaml with error %v", err)
+	}
+	return l.LoadManifest(incoming)
 }

--- a/backend/internal/versions_test.go
+++ b/backend/internal/versions_test.go
@@ -14,7 +14,7 @@ func TestSortVersionsNoErrors(t *testing.T) {
 		{
 			name: "simple test",
 			args: []string{"1.15", "1.17", "1.18", "1.16"},
-			want: []string{"1.15", "1.16", "1.17", "1.18"},
+			want: []string{"1.18", "1.17", "1.16", "1.15"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Implement parsing of YAML streams

This adds the ability to parse YAML streams (as produced by helm
template/helmfile template). As those tools might spill out empty
manifests and kubeyaml fails on those, I've addd an option to ignore
them.
    
Fixes https://github.com/chuckha/kubeyaml/issues/7